### PR TITLE
Let visitors abort or prune a BFS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ noinst_PROGRAMS = \
 	judyltables
 check_LTLIBRARIES = libtests.la
 check_PROGRAMS = \
+	tests/test-bfs \
 	tests/test-csp0 \
 	tests/test-denotational \
 	tests/test-environment \
@@ -255,6 +256,7 @@ hst_SOURCES = \
 hst_LDADD = libhst.la
 
 LDADD = libhst.la libtests.la
+tests_test_bfs_LDFLAGS = -no-install
 tests_test_csp0_LDFLAGS = -no-install
 tests_test_denotational_LDFLAGS = -no-install
 tests_test_environment_LDFLAGS = -no-install

--- a/src/hst/reachable.c.in
+++ b/src/hst/reachable.c.in
@@ -22,7 +22,7 @@ struct reachable {
     bool verbose;
 };
 
-static void
+static int
 reachable_visit(struct csp *csp, struct csp_process_visitor *visitor,
                 struct csp_process *process)
 {
@@ -33,6 +33,7 @@ reachable_visit(struct csp *csp, struct csp_process_visitor *visitor,
         csp_process_name(csp, process, &print.visitor);
         printf("\n");
     }
+    return 0;
 }
 
 struct reachable

--- a/src/normalization.c
+++ b/src/normalization.c
@@ -342,7 +342,7 @@ struct csp_init_bisimulation {
     struct csp_equivalences *equiv;
 };
 
-static void
+static int
 csp_init_bisimulation_visit_process(struct csp *csp,
                                     struct csp_process_visitor *visitor,
                                     struct csp_process *process)
@@ -355,6 +355,7 @@ csp_init_bisimulation_visit_process(struct csp *csp,
     DEBUG("  init " CSP_ID_FMT " ⇒ " CSP_ID_FMT, process->id,
           self->behavior.hash);
     csp_equivalences_add(self->equiv, self->behavior.hash, process);
+    return 0;
 }
 
 static void

--- a/src/operators/recursion.c
+++ b/src/operators/recursion.c
@@ -230,7 +230,7 @@ struct csp_find_recursive_processes {
     struct csp_process_set *set;
 };
 
-static void
+static int
 csp_find_recursive_processes_visit(struct csp *csp,
                                    struct csp_process_visitor *visitor,
                                    struct csp_process *process)
@@ -240,6 +240,7 @@ csp_find_recursive_processes_visit(struct csp *csp,
     if (process->iface == &csp_recursive_process_iface) {
         csp_process_set_add(self->set, process);
     }
+    return 0;
 }
 
 static struct csp_find_recursive_processes

--- a/src/process.h
+++ b/src/process.h
@@ -53,11 +53,11 @@ csp_collect_afters(struct csp_process_set *set);
  */
 
 struct csp_process_visitor {
-    void (*visit)(struct csp *csp, struct csp_process_visitor *visitor,
-                  struct csp_process *process);
+    int (*visit)(struct csp *csp, struct csp_process_visitor *visitor,
+                 struct csp_process *process);
 };
 
-void
+int
 csp_process_visitor_call(struct csp *csp, struct csp_process_visitor *visitor,
                          struct csp_process *process);
 
@@ -148,6 +148,13 @@ void
 csp_process_visit_transitions(struct csp *csp, struct csp_process *process,
                               struct csp_edge_visitor *visitor);
 
+#define CSP_PROCESS_BFS_CONTINUE 0
+#define CSP_PROCESS_BFS_ABORT 1
+#define CSP_PROCESS_BFS_PRUNE 2
+
+/* If your callback ever returns `PRUNE`, then we will not follow any outgoing
+ * transitions from the corresponding process.  If your callback ever returns
+ * `ABORT`, we will immediately abort the entire BFS. */
 void
 csp_process_bfs(struct csp *csp, struct csp_process *process,
                 struct csp_process_visitor *visitor);

--- a/tests/test-bfs.c
+++ b/tests/test-bfs.c
@@ -1,0 +1,86 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "process.h"
+
+#include "ccan/container_of/container_of.h"
+#include "environment.h"
+#include "event.h"
+#include "test-case-harness.h"
+
+struct test_visitor {
+    struct csp_process_visitor visitor;
+    size_t process_count;
+};
+
+/* A silly process visitor that prunes and aborts in ways that we can test. */
+static int
+test_visitor_visit(struct csp *csp, struct csp_process_visitor *visitor,
+                   struct csp_process *process)
+{
+    struct test_visitor *self =
+            container_of(visitor, struct test_visitor, visitor);
+    struct csp_contains_event contains;
+
+    /* Count this process regardless of its initials. */
+    self->process_count++;
+
+    /* If the process has `b` as an initial, don't consider ANY outgoing
+     * transitions. */
+    contains = csp_contains_event(csp_event_get("b"));
+    csp_process_visit_initials(csp, process, &contains.visitor);
+    if (contains.is_present) {
+        return CSP_PROCESS_BFS_PRUNE;
+    }
+
+    /* If the process has `c` as an initial, abort the entire BFS. */
+    contains = csp_contains_event(csp_event_get("c"));
+    csp_process_visit_initials(csp, process, &contains.visitor);
+    if (contains.is_present) {
+        return CSP_PROCESS_BFS_ABORT;
+    }
+
+    /* Otherwise continue. */
+    return CSP_PROCESS_BFS_CONTINUE;
+}
+
+static struct test_visitor
+test_visitor(void)
+{
+    struct test_visitor self = {{test_visitor_visit}, 0};
+    return self;
+}
+
+static void
+check_bfs_(const char *filename, unsigned int line,
+           struct csp_process_factory process_, size_t expected_count)
+{
+    struct csp *csp;
+    struct csp_process *process;
+    struct test_visitor visitor;
+    check_alloc(csp, csp_new());
+    process = csp_process_factory_create(csp, process_);
+    visitor = test_visitor();
+    csp_process_bfs(csp, process, &visitor.visitor);
+    check_with_msg_(filename, line, visitor.process_count == expected_count,
+                    "Unexpected process count: got %zu, expected %zu",
+                    visitor.process_count, expected_count);
+    csp_free(csp);
+}
+#define check_bfs ADD_FILE_AND_LINE(check_bfs_)
+
+TEST_CASE_GROUP("breadth-first searches");
+
+TEST_CASE("breadth-first searches") {
+    check_bfs(csp0("STOP"), 1);
+    check_bfs(csp0("a → STOP"), 2);
+    check_bfs(csp0("a → a → STOP"), 3);
+    check_bfs(csp0("b → STOP"), 1);
+    check_bfs(csp0("c → STOP"), 1);
+    check_bfs(csp0("a → STOP □ b → STOP"), 1);
+    check_bfs(csp0("a → STOP □ d → STOP"), 2);
+}


### PR DESCRIPTION
Your process visitor can now return special values that tell the BFS code to abort the search or to "prune" the current process.